### PR TITLE
Regex fix for scriptrun test

### DIFF
--- a/t/event_scriptrun.t
+++ b/t/event_scriptrun.t
@@ -13,6 +13,6 @@ my $m = Log::Message::Structured::Event::ScriptRun->new;
 
 is $m->script_name, 't/event_scriptrun.t';
 ok $m->time >= 2;
-like $m.'', qr{Script t/event_scriptrun.t run on \w+ for \d+s by \w+};
+like $m.'', qr{Script t/event_scriptrun.t run on [\w.]+ for \d+s by \w+};
 
 done_testing;


### PR DESCRIPTION
Test 3 in t/event_scriptrun.t was failing because the hostname returned by Sys::Hostname is the FQDN and the dots in there don't match the regex which was just /\w+/ (introduced in commit 3036f817731f4dab5083008ab5105520a0017a67). The new regex matches the dots as well so the test now passes.

I've been assigned this dist as part of the [CPAN Pull Request Challenge](http://cpan-prc.org/) - thank you for taking part. If there's anything in particular you think requires attention please let me know and I'll look into it.