### PR TITLE
Declare minimum perl version (5.8.0) in main module

### DIFF
--- a/lib/Log/Message/Structured.pm
+++ b/lib/Log/Message/Structured.pm
@@ -2,6 +2,7 @@ package Log::Message::Structured;
 use MooseX::Role::WithOverloading;
 use Scalar::Util qw/ blessed /;
 use namespace::clean -except => 'meta';
+use 5.008;
 
 our $VERSION = '0.012';
 $VERSION = eval $VERSION;


### PR DESCRIPTION
See [this issue](https://github.com/openstrike/log-message-structured/issues/2) in my fork. There was no minimum perl version specified in the main module which produced a warning when running Makefile.PL.